### PR TITLE
Wait for the network to be up before starting blackfire-agent

### DIFF
--- a/blackfire-agent/blackfire-agent.service
+++ b/blackfire-agent/blackfire-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Blackfire Agent
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/blackfire-agent


### PR DESCRIPTION
Should prevent errors like

```
Feb 09 12:03:31 skybox blackfire-agent[550]: [2015-02-09T12:03:31+01:00] ERROR: Error while sending request to Blackfire API: Get https://blackfire.io/agent-api/v1/public-keys: dial tcp: lookup blackfire.io: no such host
```